### PR TITLE
Add Sse Opt. for S/Umax_V, S/Umin_V, S/Uaddw_V, S/Usubw_V, Fabs_S/V Inst.; for Fcvtl_V, Fcvtn_V Inst.; and for Fcmp_S Inst.. Add/Improve other Sse Opt.. Add Tests. #496

### DIFF
--- a/ChocolArm64/Instructions/InstEmitAluHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitAluHelper.cs
@@ -190,22 +190,31 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        public static void EmitSetNzcv(ILEmitterCtx context, int nzcv)
+        public static void EmitSetNzcv(ILEmitterCtx context)
         {
-            context.EmitLdc_I4((nzcv >> 0) & 1);
-
+            context.Emit(OpCodes.Dup);
+            context.Emit(OpCodes.Ldc_I4_1);
+            context.Emit(OpCodes.And);
             context.EmitStflg((int)PState.VBit);
 
-            context.EmitLdc_I4((nzcv >> 1) & 1);
-
+            context.Emit(OpCodes.Ldc_I4_1);
+            context.Emit(OpCodes.Shr);
+            context.Emit(OpCodes.Dup);
+            context.Emit(OpCodes.Ldc_I4_1);
+            context.Emit(OpCodes.And);
             context.EmitStflg((int)PState.CBit);
 
-            context.EmitLdc_I4((nzcv >> 2) & 1);
-
+            context.Emit(OpCodes.Ldc_I4_1);
+            context.Emit(OpCodes.Shr);
+            context.Emit(OpCodes.Dup);
+            context.Emit(OpCodes.Ldc_I4_1);
+            context.Emit(OpCodes.And);
             context.EmitStflg((int)PState.ZBit);
 
-            context.EmitLdc_I4((nzcv >> 3) & 1);
-
+            context.Emit(OpCodes.Ldc_I4_1);
+            context.Emit(OpCodes.Shr);
+            context.Emit(OpCodes.Ldc_I4_1);
+            context.Emit(OpCodes.And);
             context.EmitStflg((int)PState.NBit);
         }
     }

--- a/ChocolArm64/Instructions/InstEmitSimdCmp.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCmp.cs
@@ -3,6 +3,7 @@ using ChocolArm64.State;
 using ChocolArm64.Translation;
 using System;
 using System.Reflection.Emit;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
 using static ChocolArm64.Instructions.InstEmitAluHelper;
@@ -137,7 +138,8 @@ namespace ChocolArm64.Instructions
 
             context.EmitCondBranch(lblTrue, op.Cond);
 
-            EmitSetNzcv(context, op.Nzcv);
+            context.EmitLdc_I4(op.Nzcv);
+            EmitSetNzcv(context);
 
             context.Emit(OpCodes.Br, lblEnd);
 
@@ -156,7 +158,7 @@ namespace ChocolArm64.Instructions
         public static void Fcmeq_S(ILEmitterCtx context)
         {
             if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                 && Optimizations.UseSse2)
+                                                  && Optimizations.UseSse2)
             {
                 EmitScalarSseOrSse2OpF(context, nameof(Sse.CompareEqualScalar));
             }
@@ -169,7 +171,7 @@ namespace ChocolArm64.Instructions
         public static void Fcmeq_V(ILEmitterCtx context)
         {
             if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                 && Optimizations.UseSse2)
+                                                  && Optimizations.UseSse2)
             {
                 EmitVectorSseOrSse2OpF(context, nameof(Sse.CompareEqual));
             }
@@ -182,7 +184,7 @@ namespace ChocolArm64.Instructions
         public static void Fcmge_S(ILEmitterCtx context)
         {
             if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                 && Optimizations.UseSse2)
+                                                  && Optimizations.UseSse2)
             {
                 EmitScalarSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqualScalar));
             }
@@ -195,7 +197,7 @@ namespace ChocolArm64.Instructions
         public static void Fcmge_V(ILEmitterCtx context)
         {
             if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                 && Optimizations.UseSse2)
+                                                  && Optimizations.UseSse2)
             {
                 EmitVectorSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqual));
             }
@@ -208,7 +210,7 @@ namespace ChocolArm64.Instructions
         public static void Fcmgt_S(ILEmitterCtx context)
         {
             if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                 && Optimizations.UseSse2)
+                                                  && Optimizations.UseSse2)
             {
                 EmitScalarSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanScalar));
             }
@@ -221,7 +223,7 @@ namespace ChocolArm64.Instructions
         public static void Fcmgt_V(ILEmitterCtx context)
         {
             if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                 && Optimizations.UseSse2)
+                                                  && Optimizations.UseSse2)
             {
                 EmitVectorSseOrSse2OpF(context, nameof(Sse.CompareGreaterThan));
             }
@@ -257,26 +259,142 @@ namespace ChocolArm64.Instructions
 
             bool cmpWithZero = !(op is OpCodeSimdFcond64) ? op.Bit3 : false;
 
-            //Handle NaN case.
-            //If any number is NaN, then NZCV = 0011.
-            if (cmpWithZero)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
             {
-                EmitNaNCheck(context, op.Rn);
+                if (op.Size == 0)
+                {
+                    Type[] typesCmp = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+
+                    ILLabel lblNaN = new ILLabel();
+                    ILLabel lblEnd = new ILLabel();
+
+                    context.EmitLdvec(op.Rn);
+
+                    context.Emit(OpCodes.Dup);
+                    context.EmitStvectmp();
+
+                    if (cmpWithZero)
+                    {
+                        VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+                    }
+                    else
+                    {
+                        context.EmitLdvec(op.Rm);
+                    }
+
+                    context.Emit(OpCodes.Dup);
+                    context.EmitStvectmp2();
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareOrderedScalar), typesCmp));
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareEqualOrderedScalar), typesCmp));
+
+                    context.Emit(OpCodes.Brtrue_S, lblNaN);
+
+                    context.EmitLdc_I4(0);
+
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp2();
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThanOrEqualOrderedScalar), typesCmp));
+
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp2();
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareEqualOrderedScalar), typesCmp));
+
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp2();
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareLessThanOrderedScalar), typesCmp));
+
+                    context.EmitStflg((int)PState.NBit);
+                    context.EmitStflg((int)PState.ZBit);
+                    context.EmitStflg((int)PState.CBit);
+                    context.EmitStflg((int)PState.VBit);
+
+                    context.Emit(OpCodes.Br_S, lblEnd);
+
+                    context.MarkLabel(lblNaN);
+
+                    context.EmitLdc_I4(1);
+                    context.Emit(OpCodes.Dup);
+                    context.EmitLdc_I4(0);
+                    context.Emit(OpCodes.Dup);
+
+                    context.EmitStflg((int)PState.NBit);
+                    context.EmitStflg((int)PState.ZBit);
+                    context.EmitStflg((int)PState.CBit);
+                    context.EmitStflg((int)PState.VBit);
+
+                    context.MarkLabel(lblEnd);
+                }
+                else /* if (op.Size == 1) */
+                {
+                    Type[] typesCmp = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
+
+                    ILLabel lblNaN = new ILLabel();
+                    ILLabel lblEnd = new ILLabel();
+
+                    EmitLdvecWithCastToDouble(context, op.Rn);
+
+                    context.Emit(OpCodes.Dup);
+                    context.EmitStvectmp();
+
+                    if (cmpWithZero)
+                    {
+                        VectorHelper.EmitCall(context, nameof(VectorHelper.VectorDoubleZero));
+                    }
+                    else
+                    {
+                        EmitLdvecWithCastToDouble(context, op.Rm);
+                    }
+
+                    context.Emit(OpCodes.Dup);
+                    context.EmitStvectmp2();
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrderedScalar), typesCmp));
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorDoubleZero));
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareEqualOrderedScalar), typesCmp));
+
+                    context.Emit(OpCodes.Brtrue_S, lblNaN);
+
+                    context.EmitLdc_I4(0);
+
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp2();
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThanOrEqualOrderedScalar), typesCmp));
+
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp2();
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareEqualOrderedScalar), typesCmp));
+
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp2();
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareLessThanOrderedScalar), typesCmp));
+
+                    context.EmitStflg((int)PState.NBit);
+                    context.EmitStflg((int)PState.ZBit);
+                    context.EmitStflg((int)PState.CBit);
+                    context.EmitStflg((int)PState.VBit);
+
+                    context.Emit(OpCodes.Br_S, lblEnd);
+
+                    context.MarkLabel(lblNaN);
+
+                    context.EmitLdc_I4(1);
+                    context.Emit(OpCodes.Dup);
+                    context.EmitLdc_I4(0);
+                    context.Emit(OpCodes.Dup);
+
+                    context.EmitStflg((int)PState.NBit);
+                    context.EmitStflg((int)PState.ZBit);
+                    context.EmitStflg((int)PState.CBit);
+                    context.EmitStflg((int)PState.VBit);
+
+                    context.MarkLabel(lblEnd);
+                }
             }
             else
-            {
-                EmitNaNCheck(context, op.Rn);
-                EmitNaNCheck(context, op.Rm);
-
-                context.Emit(OpCodes.Or);
-            }
-
-            ILLabel lblNaN = new ILLabel();
-            ILLabel lblEnd = new ILLabel();
-
-            context.Emit(OpCodes.Brtrue_S, lblNaN);
-
-            void EmitLoadOpers()
             {
                 EmitVectorExtractF(context, op.Rn, 0, op.Size);
 
@@ -286,7 +404,7 @@ namespace ChocolArm64.Instructions
                     {
                         context.EmitLdc_R4(0f);
                     }
-                    else /* if (Op.Size == 1) */
+                    else // if (op.Size == 1)
                     {
                         context.EmitLdc_R8(0d);
                     }
@@ -295,68 +413,18 @@ namespace ChocolArm64.Instructions
                 {
                     EmitVectorExtractF(context, op.Rm, 0, op.Size);
                 }
+
+                context.EmitLdc_I4(0);
+
+                EmitSoftFloatCall(context, nameof(SoftFloat32.FPCompare));
+
+                EmitSetNzcv(context);
             }
-
-            //Z = Rn == Rm
-            EmitLoadOpers();
-
-            context.Emit(OpCodes.Ceq);
-            context.Emit(OpCodes.Dup);
-
-            context.EmitStflg((int)PState.ZBit);
-
-            //C = Rn >= Rm
-            EmitLoadOpers();
-
-            context.Emit(OpCodes.Cgt);
-            context.Emit(OpCodes.Or);
-
-            context.EmitStflg((int)PState.CBit);
-
-            //N = Rn < Rm
-            EmitLoadOpers();
-
-            context.Emit(OpCodes.Clt);
-
-            context.EmitStflg((int)PState.NBit);
-
-            //V = 0
-            context.EmitLdc_I4(0);
-
-            context.EmitStflg((int)PState.VBit);
-
-            context.Emit(OpCodes.Br_S, lblEnd);
-
-            context.MarkLabel(lblNaN);
-
-            EmitSetNzcv(context, 0b0011);
-
-            context.MarkLabel(lblEnd);
         }
 
         public static void Fcmpe_S(ILEmitterCtx context)
         {
             Fcmp_S(context);
-        }
-
-        private static void EmitNaNCheck(ILEmitterCtx context, int reg)
-        {
-            IOpCodeSimd64 op = (IOpCodeSimd64)context.CurrOp;
-
-            EmitVectorExtractF(context, reg, 0, op.Size);
-
-            if (op.Size == 0)
-            {
-                context.EmitCall(typeof(float), nameof(float.IsNaN));
-            }
-            else if (op.Size == 1)
-            {
-                context.EmitCall(typeof(double), nameof(double.IsNaN));
-            }
-            else
-            {
-                throw new InvalidOperationException();
-            }
         }
 
         private static void EmitCmp(ILEmitterCtx context, OpCode ilOp, bool scalar)
@@ -486,7 +554,7 @@ namespace ChocolArm64.Instructions
             {
                 context.EmitLdc_R4(0f);
             }
-            else /* if (SizeF == 1) */
+            else /* if (sizeF == 1) */
             {
                 context.EmitLdc_R8(0d);
             }

--- a/ChocolArm64/Instructions/InstEmitSimdCvt.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCvt.cs
@@ -76,33 +76,54 @@ namespace ChocolArm64.Instructions
 
             int sizeF = op.Size & 1;
 
-            int elems = 4 >> sizeF;
-
-            int part = op.RegisterSize == RegisterSize.Simd128 ? elems : 0;
-
-            for (int index = 0; index < elems; index++)
+            if (Optimizations.UseSse2 && sizeF == 1)
             {
-                if (sizeF == 0)
-                {
-                    EmitVectorExtractZx(context, op.Rn, part + index, 1);
-                    context.Emit(OpCodes.Conv_U2);
+                Type[] typesMov = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+                Type[] typesCvt = new Type[] { typeof(Vector128<float>) };
 
-                    context.EmitLdarg(TranslatedSub.StateArgIdx);
+                string nameMov = op.RegisterSize == RegisterSize.Simd128
+                    ? nameof(Sse.MoveHighToLow)
+                    : nameof(Sse.MoveLowToHigh);
 
-                    context.EmitCall(typeof(SoftFloat16_32), nameof(SoftFloat16_32.FPConvert));
-                }
-                else /* if (sizeF == 1) */
-                {
-                    EmitVectorExtractF(context, op.Rn, part + index, 0);
+                context.EmitLdvec(op.Rn);
+                context.Emit(OpCodes.Dup);
 
-                    context.Emit(OpCodes.Conv_R8);
-                }
+                context.EmitCall(typeof(Sse).GetMethod(nameMov, typesMov));
 
-                EmitVectorInsertTmpF(context, index, sizeF);
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToVector128Double), typesCvt));
+
+                EmitStvecWithCastFromDouble(context, op.Rd);
             }
+            else
+            {
+                int elems = 4 >> sizeF;
 
-            context.EmitLdvectmp();
-            context.EmitStvec(op.Rd);
+                int part = op.RegisterSize == RegisterSize.Simd128 ? elems : 0;
+
+                for (int index = 0; index < elems; index++)
+                {
+                    if (sizeF == 0)
+                    {
+                        EmitVectorExtractZx(context, op.Rn, part + index, 1);
+                        context.Emit(OpCodes.Conv_U2);
+
+                        context.EmitLdarg(TranslatedSub.StateArgIdx);
+
+                        context.EmitCall(typeof(SoftFloat16_32), nameof(SoftFloat16_32.FPConvert));
+                    }
+                    else /* if (sizeF == 1) */
+                    {
+                        EmitVectorExtractF(context, op.Rn, part + index, 0);
+
+                        context.Emit(OpCodes.Conv_R8);
+                    }
+
+                    EmitVectorInsertTmpF(context, index, sizeF);
+                }
+
+                context.EmitLdvectmp();
+                context.EmitStvec(op.Rd);
+            }
         }
 
         public static void Fcvtms_Gp(ILEmitterCtx context)
@@ -121,43 +142,70 @@ namespace ChocolArm64.Instructions
 
             int sizeF = op.Size & 1;
 
-            int elems = 4 >> sizeF;
-
-            int part = op.RegisterSize == RegisterSize.Simd128 ? elems : 0;
-
-            if (part != 0)
+            if (Optimizations.UseSse2 && sizeF == 1)
             {
+                Type[] typesMov = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+                Type[] typesCvt = new Type[] { typeof(Vector128<double>) };
+
+                string nameMov = op.RegisterSize == RegisterSize.Simd128
+                    ? nameof(Sse.MoveLowToHigh)
+                    : nameof(Sse.MoveHighToLow);
+
                 context.EmitLdvec(op.Rd);
-                context.EmitStvectmp();
+                VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.MoveLowToHigh), typesMov));
+
+                EmitLdvecWithCastToDouble(context, op.Rn);
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToVector128Single), typesCvt));
+                context.Emit(OpCodes.Dup);
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.MoveLowToHigh), typesMov));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameMov, typesMov));
+
+                context.EmitStvec(op.Rd);
             }
-
-            for (int index = 0; index < elems; index++)
+            else
             {
-                EmitVectorExtractF(context, op.Rn, index, sizeF);
+                int elems = 4 >> sizeF;
 
-                if (sizeF == 0)
+                int part = op.RegisterSize == RegisterSize.Simd128 ? elems : 0;
+
+                if (part != 0)
                 {
-                    context.EmitLdarg(TranslatedSub.StateArgIdx);
-
-                    context.EmitCall(typeof(SoftFloat32_16), nameof(SoftFloat32_16.FPConvert));
-
-                    context.Emit(OpCodes.Conv_U8);
-                    EmitVectorInsertTmp(context, part + index, 1);
+                    context.EmitLdvec(op.Rd);
+                    context.EmitStvectmp();
                 }
-                else /* if (sizeF == 1) */
+
+                for (int index = 0; index < elems; index++)
                 {
-                    context.Emit(OpCodes.Conv_R4);
+                    EmitVectorExtractF(context, op.Rn, index, sizeF);
 
-                    EmitVectorInsertTmpF(context, part + index, 0);
+                    if (sizeF == 0)
+                    {
+                        context.EmitLdarg(TranslatedSub.StateArgIdx);
+
+                        context.EmitCall(typeof(SoftFloat32_16), nameof(SoftFloat32_16.FPConvert));
+
+                        context.Emit(OpCodes.Conv_U8);
+                        EmitVectorInsertTmp(context, part + index, 1);
+                    }
+                    else /* if (sizeF == 1) */
+                    {
+                        context.Emit(OpCodes.Conv_R4);
+
+                        EmitVectorInsertTmpF(context, part + index, 0);
+                    }
                 }
-            }
 
-            context.EmitLdvectmp();
-            context.EmitStvec(op.Rd);
+                context.EmitLdvectmp();
+                context.EmitStvec(op.Rd);
 
-            if (part == 0)
-            {
-                EmitVectorZeroUpper(context, op.Rd);
+                if (part == 0)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
             }
         }
 

--- a/ChocolArm64/Instructions/InstEmitSimdHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdHelper.cs
@@ -219,7 +219,7 @@ namespace ChocolArm64.Instructions
                 type     = typeof(Sse);
                 baseType = typeof(Vector128<float>);
             }
-            else /* if (SizeF == 1) */
+            else /* if (sizeF == 1) */
             {
                 type     = typeof(Sse2);
                 baseType = typeof(Vector128<double>);
@@ -249,7 +249,7 @@ namespace ChocolArm64.Instructions
                 {
                     EmitVectorZero32_128(context, op.Rd);
                 }
-                else /* if (SizeF == 1) */
+                else /* if (sizeF == 1) */
                 {
                     EmitVectorZeroUpper(context, op.Rd);
                 }
@@ -272,7 +272,7 @@ namespace ChocolArm64.Instructions
             {
                 mthdInfo = typeof(MathF).GetMethod(name, new Type[] { typeof(float) });
             }
-            else /* if (SizeF == 1) */
+            else /* if (sizeF == 1) */
             {
                 mthdInfo = typeof(Math).GetMethod(name, new Type[] { typeof(double) });
             }
@@ -292,7 +292,7 @@ namespace ChocolArm64.Instructions
             {
                 mthdInfo = typeof(MathF).GetMethod(name, new Type[] { typeof(float), typeof(float) });
             }
-            else /* if (SizeF == 1) */
+            else /* if (sizeF == 1) */
             {
                 mthdInfo = typeof(Math).GetMethod(name, new Type[] { typeof(double), typeof(double) });
             }
@@ -312,7 +312,7 @@ namespace ChocolArm64.Instructions
             {
                 mthdInfo = typeof(MathF).GetMethod(nameof(MathF.Round), new Type[] { typeof(float), typeof(MidpointRounding) });
             }
-            else /* if (SizeF == 1) */
+            else /* if (sizeF == 1) */
             {
                 mthdInfo = typeof(Math).GetMethod(nameof(Math.Round), new Type[] { typeof(double), typeof(MidpointRounding) });
             }
@@ -334,7 +334,7 @@ namespace ChocolArm64.Instructions
             {
                 mthdInfo = typeof(SoftFloat).GetMethod(name, new Type[] { typeof(float) });
             }
-            else /* if (SizeF == 1) */
+            else /* if (sizeF == 1) */
             {
                 mthdInfo = typeof(SoftFloat).GetMethod(name, new Type[] { typeof(double) });
             }
@@ -961,7 +961,7 @@ namespace ChocolArm64.Instructions
                 {
                     EmitSatQ(context, op.Size, true, true);
                 }
-                else /* if (Op.Size == 3) */
+                else /* if (op.Size == 3) */
                 {
                     EmitUnarySignedSatQAbsOrNeg(context);
                 }
@@ -1022,7 +1022,7 @@ namespace ChocolArm64.Instructions
             {
                 for (int index = 0; index < elems; index++)
                 {
-                    EmitVectorExtract(context,                   op.Rn, index, op.Size, signed);
+                    EmitVectorExtract(context,                   op.Rn,  index, op.Size, signed);
                     EmitVectorExtract(context, ((OpCodeSimdReg64)op).Rm, index, op.Size, signed);
 
                     if (op.Size <= 2)
@@ -1031,13 +1031,13 @@ namespace ChocolArm64.Instructions
 
                         EmitSatQ(context, op.Size, true, signed);
                     }
-                    else /* if (Op.Size == 3) */
+                    else /* if (op.Size == 3) */
                     {
                         if (add)
                         {
                             EmitBinarySatQAdd(context, signed);
                         }
-                        else /* if (Sub) */
+                        else /* if (sub) */
                         {
                             EmitBinarySatQSub(context, signed);
                         }
@@ -1059,7 +1059,7 @@ namespace ChocolArm64.Instructions
 
                         EmitSatQ(context, op.Size, true, signed);
                     }
-                    else /* if (Op.Size == 3) */
+                    else /* if (op.Size == 3) */
                     {
                         EmitBinarySatQAccumulate(context, signed);
                     }
@@ -1071,7 +1071,7 @@ namespace ChocolArm64.Instructions
             {
                 for (int index = 0; index < elems; index++)
                 {
-                    EmitVectorExtract(context,                   op.Rn, index, op.Size, signed);
+                    EmitVectorExtract(context,                   op.Rn,  index, op.Size, signed);
                     EmitVectorExtract(context, ((OpCodeSimdReg64)op).Rm, index, op.Size, signed);
 
                     emit();
@@ -1304,52 +1304,64 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        public static void EmitVectorZeroAll(ILEmitterCtx context, int rd)
+        public static void EmitVectorZeroAll(ILEmitterCtx context, int reg)
         {
-            if (Optimizations.UseSse2)
+            if (Optimizations.UseSse)
             {
                 VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
 
-                context.EmitStvec(rd);
+                context.EmitStvec(reg);
             }
             else
             {
-                EmitVectorZeroLower(context, rd);
-                EmitVectorZeroUpper(context, rd);
+                EmitVectorZeroLower(context, reg);
+                EmitVectorZeroUpper(context, reg);
             }
         }
 
-        public static void EmitVectorZeroLower(ILEmitterCtx context, int rd)
+        public static void EmitVectorZeroLower(ILEmitterCtx context, int reg)
         {
-            EmitVectorInsert(context, rd, 0, 3, 0);
+            EmitVectorInsert(context, reg, 0, 3, 0);
         }
 
         public static void EmitVectorZeroLowerTmp(ILEmitterCtx context)
         {
-            EmitVectorInsertTmp(context, 0, 3, 0);
+            if (Optimizations.UseSse)
+            {
+                context.EmitLdvectmp();
+                VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.MoveHighToLow)));
+
+                context.EmitStvectmp();
+            }
+            else
+            {
+                EmitVectorInsertTmp(context, 0, 3, 0);
+            }
         }
 
         public static void EmitVectorZeroUpper(ILEmitterCtx context, int reg)
         {
-            if (Optimizations.UseSse2)
+            if (Optimizations.UseSse)
             {
-                //TODO: Use MoveScalar once it is fixed, as of the
-                //time of writing it just crashes the JIT.
+                //TODO: Use Sse2.MoveScalar once it is fixed,
+                //as of the time of writing it just crashes the JIT (SDK 2.1.403).
+
+                /*Type[] typesMov = new Type[] { typeof(Vector128<ulong>) };
+
                 EmitLdvecWithUnsignedCast(context, reg, 3);
 
-                Type[] types = new Type[] { typeof(Vector128<ulong>), typeof(byte) };
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.MoveScalar), typesMov));
 
-                //Context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.MoveScalar), Types));
+                EmitStvecWithUnsignedCast(context, reg, 3);*/
 
-                context.EmitLdc_I4(8);
+                context.EmitLdvec(reg);
+                VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ShiftLeftLogical128BitLane), types));
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.MoveLowToHigh)));
 
-                context.EmitLdc_I4(8);
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ShiftRightLogical128BitLane), types));
-
-                EmitStvecWithUnsignedCast(context, reg, 3);
+                context.EmitStvec(reg);
             }
             else
             {
@@ -1359,9 +1371,15 @@ namespace ChocolArm64.Instructions
 
         public static void EmitVectorZero32_128(ILEmitterCtx context, int reg)
         {
+            if (!Sse.IsSupported)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
             context.EmitLdvec(reg);
 
-            VectorHelper.EmitCall(context, nameof(VectorHelper.VectorZero32_128));
+            context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.MoveScalar)));
 
             context.EmitStvec(reg);
         }

--- a/ChocolArm64/Instructions/SoftFloat.cs
+++ b/ChocolArm64/Instructions/SoftFloat.cs
@@ -789,6 +789,43 @@ namespace ChocolArm64.Instructions
             return result;
         }
 
+        public static int FPCompare(float value1, float value2, bool signalNaNs, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPCompare: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out bool sign1, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out bool sign2, out _, state);
+
+            int result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = 0b0011;
+
+                if (type1 == FpType.SNaN || type2 == FpType.SNaN || signalNaNs)
+                {
+                    FPProcessException(FpExc.InvalidOp, state);
+                }
+            }
+            else
+            {
+                if (value1 == value2)
+                {
+                    result = 0b0110;
+                }
+                else if (value1 < value2)
+                {
+                    result = 0b1000;
+                }
+                else
+                {
+                    result = 0b0010;
+                }
+            }
+
+            return result;
+        }
+
         public static float FPDiv(float value1, float value2, CpuThreadState state)
         {
             Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPDiv: state.Fpcr = 0x{state.Fpcr:X8}");
@@ -1578,6 +1615,43 @@ namespace ChocolArm64.Instructions
 
                         result = FPZero(result < 0d);
                     }
+                }
+            }
+
+            return result;
+        }
+
+        public static int FPCompare(double value1, double value2, bool signalNaNs, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPCompare: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out bool sign1, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out bool sign2, out _, state);
+
+            int result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = 0b0011;
+
+                if (type1 == FpType.SNaN || type2 == FpType.SNaN || signalNaNs)
+                {
+                    FPProcessException(FpExc.InvalidOp, state);
+                }
+            }
+            else
+            {
+                if (value1 == value2)
+                {
+                    result = 0b0110;
+                }
+                else if (value1 < value2)
+                {
+                    result = 0b1000;
+                }
+                else
+                {
+                    result = 0b0010;
                 }
             }
 

--- a/ChocolArm64/Instructions/VectorHelper.cs
+++ b/ChocolArm64/Instructions/VectorHelper.cs
@@ -9,18 +9,6 @@ namespace ChocolArm64.Instructions
 {
     static class VectorHelper
     {
-        private static readonly Vector128<float> Zero32128Mask;
-
-        static VectorHelper()
-        {
-            if (!Sse2.IsSupported)
-            {
-                throw new PlatformNotSupportedException();
-            }
-
-            Zero32128Mask = Sse.StaticCast<uint, float>(Sse2.SetVector128(0, 0, 0, 0xffffffff));
-        }
-
         public static void EmitCall(ILEmitterCtx context, string name64, string name128)
         {
             bool isSimd64 = context.CurrOp.RegisterSize == RegisterSize.Simd64;
@@ -491,7 +479,7 @@ namespace ChocolArm64.Instructions
             {
                 int intValue = BitConverter.SingleToInt32Bits(value);
 
-                ushort low  = (ushort)(intValue >> 0);
+                ushort low  = (ushort)(intValue >>  0);
                 ushort high = (ushort)(intValue >> 16);
 
                 Vector128<ushort> shortVector = Sse.StaticCast<float, ushort>(vector);
@@ -573,17 +561,6 @@ namespace ChocolArm64.Instructions
             if (Sse2.IsSupported)
             {
                 return Sse2.SetZeroVector128<double>();
-            }
-
-            throw new PlatformNotSupportedException();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector128<float> VectorZero32_128(Vector128<float> vector)
-        {
-            if (Sse.IsSupported)
-            {
-                return Sse.And(vector, Zero32128Mask);
             }
 
             throw new PlatformNotSupportedException();

--- a/Ryujinx.Tests/Cpu/CpuTest.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest.cs
@@ -333,7 +333,6 @@ namespace Ryujinx.Tests.Cpu
             Assert.That(_thread.ThreadState.V29, Is.EqualTo(_unicornEmu.Q[29]));
             Assert.That(_thread.ThreadState.V30, Is.EqualTo(_unicornEmu.Q[30]));
             Assert.That(_thread.ThreadState.V31, Is.EqualTo(_unicornEmu.Q[31]));
-            Assert.That(_thread.ThreadState.V31, Is.EqualTo(_unicornEmu.Q[31]));
 
             Assert.That(_thread.ThreadState.Fpcr,                 Is.EqualTo(_unicornEmu.Fpcr));
             Assert.That(_thread.ThreadState.Fpsr & (int)fpsrMask, Is.EqualTo(_unicornEmu.Fpsr & (int)fpsrMask));

--- a/Ryujinx.Tests/Cpu/CpuTestSimdReg.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdReg.cs
@@ -250,6 +250,22 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
+        private static uint[] _F_Cmp_S_S_()
+        {
+            return new uint[]
+            {
+                0x1E222020u // FCMP S1, S2
+            };
+        }
+
+        private static uint[] _F_Cmp_S_D_()
+        {
+            return new uint[]
+            {
+                0x1E622020u // FCMP D1, D2
+            };
+        }
+
         private static uint[] _F_Madd_Msub_S_S_()
         {
             return new uint[]
@@ -370,6 +386,28 @@ namespace Ryujinx.Tests.Cpu
                 0x5E004000u, // SHA256H   Q0,    Q0,    V0.4S
                 0x5E005000u, // SHA256H2  Q0,    Q0,    V0.4S
                 0x5E006000u  // SHA256SU1 V0.4S, V0.4S, V0.4S
+            };
+        }
+
+        private static uint[] _S_Max_Min_P_V_()
+        {
+            return new uint[]
+            {
+                0x0E206400u, // SMAX  V0.8B, V0.8B, V0.8B
+                0x0E20A400u, // SMAXP V0.8B, V0.8B, V0.8B
+                0x0E206C00u, // SMIN  V0.8B, V0.8B, V0.8B
+                0x0E20AC00u  // SMINP V0.8B, V0.8B, V0.8B
+            };
+        }
+
+        private static uint[] _U_Max_Min_P_V_()
+        {
+            return new uint[]
+            {
+                0x2E206400u, // UMAX  V0.8B, V0.8B, V0.8B
+                0x2E20A400u, // UMAXP V0.8B, V0.8B, V0.8B
+                0x2E206C00u, // UMIN  V0.8B, V0.8B, V0.8B
+                0x2E20AC00u  // UMINP V0.8B, V0.8B, V0.8B
             };
         }
 #endregion
@@ -1248,6 +1286,42 @@ namespace Ryujinx.Tests.Cpu
             CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Dzc | Fpsr.Idc);
         }
 
+        [Test, Pairwise] [Explicit]
+        public void F_Cmp_S_S([ValueSource("_F_Cmp_S_S_")] uint opcodes,
+                              [ValueSource("_1S_F_")] ulong a,
+                              [ValueSource("_1S_F_")] ulong b)
+        {
+            Vector128<float> v1 = MakeVectorE0(a);
+            Vector128<float> v2 = MakeVectorE0(b);
+
+            bool v = TestContext.CurrentContext.Random.NextBool();
+            bool c = TestContext.CurrentContext.Random.NextBool();
+            bool z = TestContext.CurrentContext.Random.NextBool();
+            bool n = TestContext.CurrentContext.Random.NextBool();
+
+            SingleOpcode(opcodes, v1: v1, v2: v2, overflow: v, carry: c, zero: z, negative: n);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cmp_S_D([ValueSource("_F_Cmp_S_D_")] uint opcodes,
+                              [ValueSource("_1D_F_")] ulong a,
+                              [ValueSource("_1D_F_")] ulong b)
+        {
+            Vector128<float> v1 = MakeVectorE0(a);
+            Vector128<float> v2 = MakeVectorE0(b);
+
+            bool v = TestContext.CurrentContext.Random.NextBool();
+            bool c = TestContext.CurrentContext.Random.NextBool();
+            bool z = TestContext.CurrentContext.Random.NextBool();
+            bool n = TestContext.CurrentContext.Random.NextBool();
+
+            SingleOpcode(opcodes, v1: v1, v2: v2, overflow: v, carry: c, zero: z, negative: n);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc);
+        }
+
         [Test, Pairwise] [Explicit] // Fused.
         public void F_Madd_Msub_S_S([ValueSource("_F_Madd_Msub_S_S_")] uint opcodes,
                                     [ValueSource("_1S_F_")] ulong a,
@@ -2032,6 +2106,30 @@ namespace Ryujinx.Tests.Cpu
             Vector128<float> v2 = MakeVectorE0E1(b, b);
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise]
+        public void S_Max_Min_P_V([ValueSource("_S_Max_Min_P_V_")] uint opcodes,
+                                  [Values(0u)]     uint rd,
+                                  [Values(1u, 0u)] uint rn,
+                                  [Values(2u, 0u)] uint rm,
+                                  [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong z,
+                                  [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong a,
+                                  [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong b,
+                                  [Values(0b00u, 0b01u, 0b10u)] uint size, // Q0: <8B,  4H, 2S>
+                                  [Values(0b0u, 0b1u)] uint q)             // Q1: <16B, 8H, 4S>
+        {
+            opcodes |= ((rm & 31) << 16) | ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= ((size & 3) << 22);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a * q);
+            Vector128<float> v2 = MakeVectorE0E1(b, b * q);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, v2: v2);
 
             CompareAgainstUnicorn();
         }
@@ -3064,6 +3162,30 @@ namespace Ryujinx.Tests.Cpu
             Vector128<float> v2 = MakeVectorE0E1(b, b);
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise]
+        public void U_Max_Min_P_V([ValueSource("_U_Max_Min_P_V_")] uint opcodes,
+                                  [Values(0u)]     uint rd,
+                                  [Values(1u, 0u)] uint rn,
+                                  [Values(2u, 0u)] uint rm,
+                                  [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong z,
+                                  [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong a,
+                                  [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong b,
+                                  [Values(0b00u, 0b01u, 0b10u)] uint size, // Q0: <8B,  4H, 2S>
+                                  [Values(0b0u, 0b1u)] uint q)             // Q1: <16B, 8H, 4S>
+        {
+            opcodes |= ((rm & 31) << 16) | ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= ((size & 3) << 22);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a * q);
+            Vector128<float> v2 = MakeVectorE0E1(b, b * q);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, v2: v2);
 
             CompareAgainstUnicorn();
         }


### PR DESCRIPTION
Added Sse Opt. (inst.s):

InstEmitSimdArithmetic:

Smax_V, Umax_V;
Smin_V, Umin_V:

  • Max Sse Req.: Sse41
  •  Types Covered: All

Saddw_V, Uaddw_V;
Ssubw_V, Usubw_V:

  Max Sse Req.: Sse41 (ConvertToVector128Int* [16, 32, 64])
  Types Covered: All

Fabs_S;
Fabs_V:

   - Max Sse Req.: Sse2
   - Types Covered: All

InstEmitSimdCvt:

Fcvtl_V:

   - Max Sse Req.: Sse2
   - Type Covered: float (low/high) -> double

Fcvtn_V:

   - Max Sse Req.: Sse2
   - Type Covered: double -> float (low/high)

InstEmitSimdCmp:

Fcmp_S:

   - Max Sse Req.: Sse2
   - Types Covered: All

Also added slow path (SoftFloat): FPCompare()
Added Sse Opt. (mthd.s):

InstEmitSimdHelper:

EmitVectorZeroLowerTmp()
Improved Sse Opt. (mthd.s):

InstEmitSimdHelper:

EmitVectorZeroUpper()
EmitVectorZero32_128()
Added Tests:

Smax_V, Umax_V
Smin_V, Umin_V

Fabs_S
Fabs_V

Fcmp_S (& Zero)

Nits.