### PR TITLE
Only enumerate cached textures that are modified when flushing. (#918)

### DIFF
--- a/Ryujinx.Common/ReferenceEqualityComparer.cs
+++ b/Ryujinx.Common/ReferenceEqualityComparer.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Ryujinx.Common
+{
+    public class ReferenceEqualityComparer<T> : IEqualityComparer<T>
+        where T : class
+    {
+        public bool Equals(T x, T y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode([DisallowNull] T obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -94,7 +94,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 srcTexture.HostTexture.CopyTo(dstTexture.HostTexture, srcRegion, dstRegion, linearFilter);
             }
 
-            dstTexture.Modified = true;
+            dstTexture.SignalModified();
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -286,7 +286,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (color != null)
                 {
-                    color.Modified = true;
+                    color.SignalModified();
                 }
             }
 
@@ -306,7 +306,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             if (depthStencil != null)
             {
-                depthStencil.Modified = true;
+                depthStencil.SignalModified();
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -54,9 +54,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         public LinkedListNode<Texture> CacheNode { get; set; }
 
         /// <summary>
-        /// Texture data modified by the GPU.
+        /// Event to fire when texture data is modified by the GPU.
         /// </summary>
-        public bool Modified { get; set; }
+        public event Action<Texture> Modified;
+
+        /// <summary>
+        /// Event to fire when texture data is disposed.
+        /// </summary>
+        public event Action<Texture> Disposed;
 
         /// <summary>
         /// Start address of the texture in guest memory.
@@ -934,6 +939,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Signals that the texture has been modified.
+        /// </summary>
+        public void SignalModified()
+        {
+            Modified?.Invoke(this);
+        }
+
+        /// <summary>
         /// Replaces the host texture, while disposing of the old one if needed.
         /// </summary>
         /// <param name="hostTexture">The new host texture</param>
@@ -1012,6 +1025,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _arrayViewTexture?.Dispose();
             _arrayViewTexture = null;
+
+            Disposed?.Invoke(this);
         }
 
         /// <summary>


### PR DESCRIPTION
* Only enumarate cached textures that are modified when flushing, rather than all of them.

* Remove locking.

* Add missing clear.

* Remove texture from modified list when data is disposed.

In case the game does not call either flush method at any point.

* Add ReferenceEqualityComparer from jD for the HashSet