### PR TITLE
Some fixes for the new GLRenderer

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Ui
 
         private static GLRenderer _gLWidget;
 
-        private static AutoResetEvent _screenExitStatus = new AutoResetEvent(false);
+        private static AutoResetEvent _deviceExitStatus = new AutoResetEvent(false);
 
         private static ListStore _tableStore;
 
@@ -356,7 +356,7 @@ namespace Ryujinx.Ui
 
                 _emulationContext = device;
 
-                _screenExitStatus.Reset();
+                _deviceExitStatus.Reset();
 
 #if MACOS_BUILD
                 CreateGameWindow(device);
@@ -391,8 +391,6 @@ namespace Ryujinx.Ui
         {
             device.Hid.InitializePrimaryController(ConfigurationState.Instance.Hid.ControllerType);
 
-            _gLWidget?.Exit();
-            _gLWidget?.Dispose();
             _gLWidget = new GLRenderer(_emulationContext);
 
             Application.Invoke(delegate
@@ -409,6 +407,10 @@ namespace Ryujinx.Ui
 
             _gLWidget.Start();
 
+            device.Dispose();
+            _deviceExitStatus.Set();
+
+            // NOTE: Everything that is here will not be executed when you close the UI.
             Application.Invoke(delegate
             {
                 _viewBox.Remove(_gLWidget);
@@ -419,11 +421,19 @@ namespace Ryujinx.Ui
                     _gLWidget.Window.Dispose();
                 }
 
+                _gLWidget.Dispose();
+
                 _viewBox.Add(_gameTableWindow);
 
                 _gameTableWindow.Expand = true;
 
                 this.Window.Title = "Ryujinx";
+
+                _emulationContext = null;
+                _gameLoaded       = false;
+                _gLWidget         = null;
+
+                DiscordIntegrationModule.SwitchToMainMenu();
 
                 _listStatusBox.ShowAll();
 
@@ -431,24 +441,11 @@ namespace Ryujinx.Ui
                 UpdateGameTable();
 
                 Task.Run(RefreshFirmwareLabel);
-            });
 
-            device.Dispose();
-
-            _emulationContext = null;
-            _gameLoaded       = false;
-            _gLWidget         = null;
-
-            DiscordIntegrationModule.SwitchToMainMenu();
-
-            Application.Invoke(delegate
-            {
                 _stopEmulation.Sensitive            = false;
                 _firmwareInstallFile.Sensitive      = true;
                 _firmwareInstallDirectory.Sensitive = true;
             });
-
-            _screenExitStatus.Set();
         }
 
         public void ToggleExtraWidgets(bool show)
@@ -469,7 +466,7 @@ namespace Ryujinx.Ui
 
             bool fullScreenToggled = this.Window.State.HasFlag(Gdk.WindowState.Fullscreen);
 
-            _fullScreen.Label = !fullScreenToggled ? "Exit Fullscreen" : "Enter Fullscreen";
+            _fullScreen.Label = fullScreenToggled ? "Exit Fullscreen" : "Enter Fullscreen";
         }
 
         private static void UpdateGameMetadata(string titleId)
@@ -506,8 +503,11 @@ namespace Ryujinx.Ui
 
                 if (_gLWidget != null)
                 {
+                    // We tell the widget that we are exiting
                     _gLWidget.Exit();
-                    _screenExitStatus.WaitOne();
+
+                    // Wait for the other thread to dispose the HLE context before exiting.
+                    _deviceExitStatus.WaitOne();
                 }
             }
 
@@ -874,17 +874,13 @@ namespace Ryujinx.Ui
             {
                 Fullscreen();
 
-                _fullScreen.Label = "Exit Fullscreen";
-
-                ToggleExtraWidgets(false);
+                ToggleExtraWidgets(true);
             }
             else
             {
                 Unfullscreen();
 
-                _fullScreen.Label = "Enter Fullscreen";
-
-                ToggleExtraWidgets(true);
+                ToggleExtraWidgets(false);
             }
         }
 


### PR DESCRIPTION
Changelog:
- Fix transparency of the window on some games on Windows.
- Fix escape key not being able to exit emulation.
- Fix inverted logic in fullscreen event handling.
- Fix a race condition when stoping emulation causing a hang.
- Fix a memory leak of the OpenGL context when stoping emulation (saving ~200MB of RAM when stoping emulation).
- Simplify and document behaviours when exiting the emulator while the
emulation is running.