### PR TITLE
Reduce requirements for running homebrews

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -23,6 +23,7 @@ namespace Ryujinx.HLE.FileSystem.Content
         private Dictionary<StorageId, LinkedList<LocationEntry>> _locationEntries;
 
         private Dictionary<string, long>   _sharedFontTitleDictionary;
+        private Dictionary<long, string>   _systemTitlesNameDictionary;
         private Dictionary<string, string> _sharedFontFilenameDictionary;
 
         private SortedDictionary<(ulong titleId, NcaContentType type), string> _contentDictionary;
@@ -44,6 +45,17 @@ namespace Ryujinx.HLE.FileSystem.Content
                 { "FontKorean",                    0x0100000000000812 },
                 { "FontChineseTraditional",        0x0100000000000813 },
                 { "FontNintendoExtended",          0x0100000000000810 }
+            };
+
+            _systemTitlesNameDictionary = new Dictionary<long, string>()
+            {
+                { 0x010000000000080E, "TimeZoneBinary"         },
+                { 0x0100000000000810, "FontNintendoExtension"  },
+                { 0x0100000000000811, "FontStandard"           },
+                { 0x0100000000000812, "FontKorean"             },
+                { 0x0100000000000813, "FontChineseTraditional" },
+                { 0x0100000000000814, "FontChineseSimple"      },
+
             };
 
             _sharedFontFilenameDictionary = new Dictionary<string, string>
@@ -342,6 +354,11 @@ namespace Ryujinx.HLE.FileSystem.Content
         public bool TryGetFontFilename(string fontName, out string filename)
         {
             return _sharedFontFilenameDictionary.TryGetValue(fontName, out filename);
+        }
+
+        public bool TryGetSystemTitlesName(long titleId, out string name)
+        {
+            return _systemTitlesNameDictionary.TryGetValue(titleId, out name);
         }
 
         private LocationEntry GetLocation(long titleId, NcaContentType contentType, StorageId storageId)

--- a/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
@@ -2,9 +2,11 @@ using LibHac.Common;
 using LibHac.Fs;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.FileSystem.Content;
+using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -18,8 +20,6 @@ namespace Ryujinx.HLE.HOS.Font
         private Switch _device;
 
         private long _physicalAddress;
-
-        private string _fontsPath;
 
         private struct FontInfo
         {
@@ -38,10 +38,7 @@ namespace Ryujinx.HLE.HOS.Font
         public SharedFontManager(Switch device, long physicalAddress)
         {
             _physicalAddress = physicalAddress;
-
-            _device = device;
-
-            _fontsPath = Path.Combine(device.FileSystem.GetSystemPath(), "fonts");
+            _device          = device;
         }
 
         public void Initialize(ContentManager contentManager)
@@ -49,7 +46,6 @@ namespace Ryujinx.HLE.HOS.Font
             _fontData?.Clear();
             _fontData = null;
 
-            EnsureInitialized(contentManager);
         }
 
         public void EnsureInitialized(ContentManager contentManager)
@@ -97,32 +93,19 @@ namespace Ryujinx.HLE.HOS.Font
 
                             return info;
                         }
-                    }
-
-                    string fontFilePath = Path.Combine(_fontsPath, name + ".ttf");
-
-                    if (File.Exists(fontFilePath))
-                    {
-                        byte[] data = File.ReadAllBytes(fontFilePath);
-
-                        FontInfo info = new FontInfo((int)fontOffset, data.Length);
-
-                        WriteMagicAndSize(_physicalAddress + fontOffset, data.Length);
-
-                        fontOffset += 8;
-
-                        uint start = fontOffset;
-
-                        for (; fontOffset - start < data.Length; fontOffset++)
+                        else
                         {
-                            _device.Memory.WriteByte(_physicalAddress + fontOffset, data[fontOffset - start]);
-                        }
+                            if (!contentManager.TryGetSystemTitlesName(fontTitle, out string titleName))
+                            {
+                                titleName = "Unknown";
+                            }
 
-                        return info;
+                            throw new InvalidSystemResourceException($"{titleName} ({fontTitle:x8}) system title not found! This font will not work, provide the system archive to fix this error. (See https://github.com/Ryujinx/Ryujinx#requirements for more informations)");
+                        }
                     }
                     else
                     {
-                        throw new InvalidSystemResourceException($"Font \"{name}.ttf\" not found. Please provide it in \"{_fontsPath}\".");
+                        throw new ArgumentException($"Unknown font \"{name}\"!");
                     }
                 }
 

--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
@@ -21,6 +21,8 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
     {
         private const long TimeZoneBinaryTitleId = 0x010000000000080E;
 
+        private readonly string TimeZoneSystemTitleMissingErrorMessage = "TimeZoneBinary system title not found! TimeZone conversions will not work, provide the system archive to fix this error. (See https://github.com/Ryujinx/Ryujinx#requirements for more informations)";
+
         private VirtualFileSystem   _virtualFileSystem;
         private IntegrityCheckLevel _fsIntegrityCheckLevel;
         private ContentManager      _contentManager;
@@ -111,7 +113,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
             {
                 LocationNameCache = new string[] { "UTC" };
 
-                Logger.PrintWarning(LogClass.ServiceTime, "TimeZoneBinary system title not found! TimeZone conversions will not work, provide the system archive to fix this warning. (See https://github.com/Ryujinx/Ryujinx#requirements for more informations)");
+                Logger.PrintError(LogClass.ServiceTime, TimeZoneSystemTitleMissingErrorMessage);
             }
         }
 
@@ -186,7 +188,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
             timeZoneBinaryStream = null;
             ncaFile              = null;
 
-            if (!IsLocationNameValid(locationName))
+            if (!HasTimeZoneBinaryTitle() || !IsLocationNameValid(locationName))
             {
                 return ResultCode.TimeZoneNotFound;
             }
@@ -215,7 +217,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
 
             if (!HasTimeZoneBinaryTitle())
             {
-                throw new InvalidSystemResourceException($"TimeZoneBinary system title not found! Please provide it. (See https://github.com/Ryujinx/Ryujinx#requirements for more informations)");
+                throw new InvalidSystemResourceException(TimeZoneSystemTitleMissingErrorMessage);
             }
 
             ResultCode result = GetTimeZoneBinary(locationName, out Stream timeZoneBinaryStream, out LocalStorage ncaFile);


### PR DESCRIPTION
This commit change the following behaviours:

- TimeZoneBinary system archive isn't required until guest code call LoadTimeZoneRule.
- Fonts system archives aren't requred until a "pl:u" IPC call is made.
- Custom font support was dropped.
- TimeZoneBinary missing message is now an error and not a warning.