### PR TITLE
Ensure account save data exists when launching an extracted game

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -254,6 +254,11 @@ namespace Ryujinx.HLE.HOS
             LocalFileSystem codeFs = new LocalFileSystem(exeFsDir);
 
             LoadExeFs(codeFs, out _);
+
+            if (TitleId != 0)
+            {
+                EnsureSaveData(new TitleId(TitleId));
+            }
         }
 
         public void LoadXci(string xciFile)
@@ -755,14 +760,14 @@ namespace Ryujinx.HLE.HOS
 
             FileSystemClient fs = Device.FileSystem.FsClient;
 
-            Result rc = fs.EnsureApplicationCacheStorage(out _, titleId, ref ControlData.Value);
+            Result rc = fs.EnsureApplicationCacheStorage(out _, titleId, ref control);
 
             if (rc.IsFailure())
             {
                 Logger.PrintError(LogClass.Application, $"Error calling EnsureApplicationCacheStorage. Result code {rc.ToStringWithName()}");
             }
 
-            rc = EnsureApplicationSaveData(fs, out _, titleId, ref ControlData.Value, ref user);
+            rc = EnsureApplicationSaveData(fs, out _, titleId, ref control, ref user);
 
             if (rc.IsFailure())
             {


### PR DESCRIPTION
Also fix a regression from cecbd256 where the dummy control data wouldn't be used