### PR TITLE
Update to LibHac 0.11.1 (1186)

### DIFF
--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -52,7 +52,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
-    <PackageReference Include="LibHac" Version="0.11.0" />
+    <PackageReference Include="LibHac" Version="0.11.1" />
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Adds EnumerateDeliveryCacheDirectory to BCAT