### PR TITLE
Add various error codes to BCAT (1202)

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Bcat/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ResultCode.cs
@@ -7,8 +7,23 @@ namespace Ryujinx.HLE.HOS.Services.Bcat
 
         Success = 0,
 
-        NullArgument = (2  << ErrorCodeShift) | ModuleId,
-        NullSaveData = (31 << ErrorCodeShift) | ModuleId,
-        NullObject   = (91 << ErrorCodeShift) | ModuleId
+        InvalidArgument                   = (1 << ErrorCodeShift) | ModuleId,
+        NotFound                          = (2 << ErrorCodeShift) | ModuleId,
+        TargetLocked                      = (3 << ErrorCodeShift) | ModuleId,
+        TargetAlreadyMounted              = (4 << ErrorCodeShift) | ModuleId,
+        TargetNotMounted                  = (5 << ErrorCodeShift) | ModuleId,
+        AlreadyOpen                       = (6 << ErrorCodeShift) | ModuleId,
+        NotOpen                           = (7 << ErrorCodeShift) | ModuleId,
+        InternetRequestDenied             = (8 << ErrorCodeShift) | ModuleId,
+        ServiceOpenLimitReached           = (9 << ErrorCodeShift) | ModuleId,
+        SaveDataNotFound                  = (10 << ErrorCodeShift) | ModuleId,
+        NetworkServiceAccountNotAvailable = (31 << ErrorCodeShift) | ModuleId,
+        PassphrasePathNotFound            = (80 << ErrorCodeShift) | ModuleId,
+        DataVerificationFailed            = (81 << ErrorCodeShift) | ModuleId,
+        PermissionDenied                  = (90 << ErrorCodeShift) | ModuleId,
+        AllocationFailed                  = (91 << ErrorCodeShift) | ModuleId,
+        InvalidOperation                  = (98 << ErrorCodeShift) | ModuleId,
+        InvalidDeliveryCacheStorageFile   = (204 << ErrorCodeShift) | ModuleId,
+        StorageOpenLimitReached           = (205 << ErrorCodeShift) | ModuleId
     }
 }


### PR DESCRIPTION
* Add various error codes to BCAT

The error codes were taken from Switchbrew (switchbrew.org/wiki/Error_codes)

As for InternetRequestDenied, it seems that this error is common for multiple services like Account for example
I already added this error code in Account in PR 1182

* Add some results codes from Libhac and keep names consistent