### PR TITLE
Fix SystemInfo logging to file

### DIFF
--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -43,12 +43,6 @@ namespace Ryujinx
             // Initialize Discord integration
             DiscordIntegrationModule.Initialize();
 
-            Logger.PrintInfo(LogClass.Application, $"Ryujinx Version: {Version}");
-
-            Logger.PrintInfo(LogClass.Application, $"Operating System: {SystemInfo.Instance.OsDescription}");
-            Logger.PrintInfo(LogClass.Application, $"CPU: {SystemInfo.Instance.CpuName}");
-            Logger.PrintInfo(LogClass.Application, $"Total RAM: {SystemInfo.Instance.RamSizeInMB}");
-
             string localConfigurationPath  = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config.json");
             string globalBasePath          = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Ryujinx");
             string globalConfigurationPath = Path.Combine(globalBasePath, "Config.json");
@@ -81,6 +75,12 @@ namespace Ryujinx
                 ConfigurationState.Instance.LoadDefault();
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(globalConfigurationPath);
             }
+
+            Logger.PrintInfo(LogClass.Application, $"Ryujinx Version: {Version}");
+
+            Logger.PrintInfo(LogClass.Application, $"Operating System: {SystemInfo.Instance.OsDescription}");
+            Logger.PrintInfo(LogClass.Application, $"CPU: {SystemInfo.Instance.CpuName}");
+            Logger.PrintInfo(LogClass.Application, $"Total RAM: {SystemInfo.Instance.RamSizeInMB}");
 
             Profile.Initialize();
 


### PR DESCRIPTION
We currently logs system informations before we load the configuration file.
Since the logger use the configuration file (to sets if it should store the logs in a file, etc...), if we print something before the configuration init, the log file doesn't contains any system informations.
Now it's fixed.