### PR TITLE
Unwinding Follow-up. Fix a bug in JitUnwindWindows where ...

### DIFF
--- a/ARMeilleure/CodeGen/Unwinding/UnwindInfo.cs
+++ b/ARMeilleure/CodeGen/Unwinding/UnwindInfo.cs
@@ -3,16 +3,12 @@ namespace ARMeilleure.CodeGen.Unwinding
     struct UnwindInfo
     {
         public UnwindPushEntry[] PushEntries { get; }
+        public int PrologSize { get; }
 
-        public int PrologueSize { get; }
-
-        public int FixedAllocSize { get; }
-
-        public UnwindInfo(UnwindPushEntry[] pushEntries, int prologueSize, int fixedAllocSize)
+        public UnwindInfo(UnwindPushEntry[] pushEntries, int prologSize)
         {
-            PushEntries    = pushEntries;
-            PrologueSize   = prologueSize;
-            FixedAllocSize = fixedAllocSize;
+            PushEntries = pushEntries;
+            PrologSize = prologSize;
         }
     }
 }

--- a/ARMeilleure/CodeGen/Unwinding/UnwindPseudoOperation.cs
+++ b/ARMeilleure/CodeGen/Unwinding/UnwindPseudoOperation.cs
@@ -1,0 +1,11 @@
+namespace ARMeilleure.CodeGen.Unwinding
+{
+    enum UnwindPseudoOp
+    {
+        PushReg,
+        SetFrame,
+        AllocStack,
+        SaveReg,
+        SaveXmm128
+    }
+}

--- a/ARMeilleure/CodeGen/Unwinding/UnwindPushEntry.cs
+++ b/ARMeilleure/CodeGen/Unwinding/UnwindPushEntry.cs
@@ -1,20 +1,18 @@
-using ARMeilleure.IntermediateRepresentation;
-
 namespace ARMeilleure.CodeGen.Unwinding
 {
     struct UnwindPushEntry
     {
-        public int Index { get; }
+        public UnwindPseudoOp PseudoOp { get; }
+        public int PrologOffset { get; }
+        public int RegIndex { get; }
+        public int StackOffsetOrAllocSize { get; }
 
-        public RegisterType Type { get; }
-
-        public int StreamEndOffset { get; }
-
-        public UnwindPushEntry(int index, RegisterType type, int streamEndOffset)
+        public UnwindPushEntry(UnwindPseudoOp pseudoOp, int prologOffset, int regIndex = -1, int stackOffsetOrAllocSize = -1)
         {
-            Index           = index;
-            Type            = type;
-            StreamEndOffset = streamEndOffset;
+            PseudoOp = pseudoOp;
+            PrologOffset = prologOffset;
+            RegIndex = regIndex;
+            StackOffsetOrAllocSize = stackOffsetOrAllocSize;
         }
     }
 }

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1531,30 +1531,27 @@ namespace ARMeilleure.CodeGen.X86
             context.Assembler.Pshufd(dest, dest, 0xfc);
         }
 
+        [Conditional("DEBUG")]
         private static void ValidateUnOp(Operand dest, Operand source)
         {
-#if DEBUG
             EnsureSameReg (dest, source);
             EnsureSameType(dest, source);
-#endif
         }
 
+        [Conditional("DEBUG")]
         private static void ValidateBinOp(Operand dest, Operand src1, Operand src2)
         {
-#if DEBUG
             EnsureSameReg (dest, src1);
             EnsureSameType(dest, src1, src2);
-#endif
         }
 
+        [Conditional("DEBUG")]
         private static void ValidateShift(Operand dest, Operand src1, Operand src2)
         {
-#if DEBUG
             EnsureSameReg (dest, src1);
             EnsureSameType(dest, src1);
 
             Debug.Assert(dest.Type.IsInteger() && src2.Type == OperandType.I32);
-#endif
         }
 
         private static void EnsureSameReg(Operand op1, Operand op2)
@@ -1601,7 +1598,7 @@ namespace ARMeilleure.CodeGen.X86
 
                 context.Assembler.Push(Register((X86Register)bit));
 
-                pushEntries.Add(new UnwindPushEntry(bit, RegisterType.Integer, context.StreamOffset));
+                pushEntries.Add(new UnwindPushEntry(UnwindPseudoOp.PushReg, context.StreamOffset, regIndex: bit));
 
                 mask &= ~(1 << bit);
             }
@@ -1618,6 +1615,8 @@ namespace ARMeilleure.CodeGen.X86
             if (reservedStackSize != 0)
             {
                 context.Assembler.Sub(rsp, Const(reservedStackSize), OperandType.I64);
+
+                pushEntries.Add(new UnwindPushEntry(UnwindPseudoOp.AllocStack, context.StreamOffset, stackOffsetOrAllocSize: reservedStackSize));
             }
 
             int offset = reservedStackSize;
@@ -1634,12 +1633,12 @@ namespace ARMeilleure.CodeGen.X86
 
                 context.Assembler.Movdqu(memOp, Xmm((X86Register)bit));
 
-                pushEntries.Add(new UnwindPushEntry(bit, RegisterType.Vector, context.StreamOffset));
+                pushEntries.Add(new UnwindPushEntry(UnwindPseudoOp.SaveXmm128, context.StreamOffset, bit, offset));
 
                 mask &= ~(1 << bit);
             }
 
-            return new UnwindInfo(pushEntries.ToArray(), context.StreamOffset, reservedStackSize);
+            return new UnwindInfo(pushEntries.ToArray(), context.StreamOffset);
         }
 
         private static void WriteEpilogue(CodeGenContext context)


### PR DESCRIPTION
... in case of "Vector" unwind codes the remaining unwind codes could be corrupted.
Nits.